### PR TITLE
Add commit sha to buildInfo

### DIFF
--- a/healthcheck/routes.js
+++ b/healthcheck/routes.js
@@ -5,14 +5,16 @@ const checks = require('./checks'),
 
 function getBuildInfo(extra) {
   return Promise.all([
-    versionFile.commit()
-  ]).then(([commit]) => {
+    versionFile.commit(),
+    versionFile.date()
+  ]).then(([commit, date]) => {
     let buildInfo = {
       environment: process.env.PACKAGES_ENVIRONMENT || "unknown",
       project: process.env.PACKAGES_PROJECT || "unknown",
       name: process.env.PACKAGES_NAME || "unknown",
       version: process.env.PACKAGES_VERSION || "unknown",
       commit,
+      date
     };
     if (extra) {
       return Object.assign(buildInfo, { extra });

--- a/healthcheck/routes.js
+++ b/healthcheck/routes.js
@@ -1,37 +1,44 @@
 'use strict'
 const checks = require('./checks'),
-      outputs = require('./outputs');
+      outputs = require('./outputs'),
+      versionFile = require('./versionFile');
 
 function getBuildInfo(extra) {
-  let buildInfo = {
-    environment: process.env.PACKAGES_ENVIRONMENT || "unknown",
-    project: process.env.PACKAGES_PROJECT || "unknown",
-    name: process.env.PACKAGES_NAME || "unknown",
-    version: process.env.PACKAGES_VERSION || "unknown",
-  };
-  if (extra) {
-    buildInfo.extra = extra;
-  }
-  return buildInfo;
+  return Promise.all([
+    versionFile.commit()
+  ]).then(([commit]) => {
+    let buildInfo = {
+      environment: process.env.PACKAGES_ENVIRONMENT || "unknown",
+      project: process.env.PACKAGES_PROJECT || "unknown",
+      name: process.env.PACKAGES_NAME || "unknown",
+      version: process.env.PACKAGES_VERSION || "unknown",
+      commit,
+    };
+    if (extra) {
+      return Object.assign(buildInfo, { extra });
+    } else {
+      return buildInfo;
+    }
+  });
 }
 
 function configure(config) {
   const check = new checks.CompositeCheck(config.checks);
 
   return (req, res) => {
-    check.call().then(results => {
-      const allOk = Object.values(results)
-                          .every(result => result.status === outputs.UP);
-      const output = Object.assign(
-        outputs.status(allOk),
-        results,
-        {
-          buildInfo: getBuildInfo(config.buildInfo)
-        }
-      );
-      const status = allOk ? 200 : 500;
-      res.status(status).json(output);
-    });
+    return Promise
+      .all([check.call(), getBuildInfo(config.buildInfo)])
+      .then(([results, buildInfo]) => {
+        const allOk = Object.values(results)
+                            .every(result => result.status === outputs.UP);
+        const output = Object.assign(
+          outputs.status(allOk),
+          results,
+          { buildInfo }
+        );
+        const status = allOk ? 200 : 500;
+        res.status(status).json(output);
+      });
   }
 }
 

--- a/healthcheck/versionFile.js
+++ b/healthcheck/versionFile.js
@@ -1,0 +1,20 @@
+const fs = require('fs-extra');
+const yaml = require('js-yaml');
+
+const defaultObj = {
+  commit: 'unknown'
+};
+
+const versionFile = () => {
+  const versionFilePath = `${process.env.NODE_PATH || '.'}/version`;
+
+  return fs.readFile(versionFilePath)
+    .then(yaml.safeLoad)
+    .catch((err) => defaultObj);
+}
+
+const commit = () => {
+  return versionFile().then(props => props.commit || defaultObj.commit);
+};
+
+module.exports = { commit };

--- a/healthcheck/versionFile.js
+++ b/healthcheck/versionFile.js
@@ -2,7 +2,8 @@ const fs = require('fs-extra');
 const yaml = require('js-yaml');
 
 const defaultObj = {
-  commit: 'unknown'
+  commit: 'unknown',
+  date: 'unknown'
 };
 
 const versionFile = () => {
@@ -17,4 +18,8 @@ const commit = () => {
   return versionFile().then(props => props.commit || defaultObj.commit);
 };
 
-module.exports = { commit };
+const date = () => {
+  return versionFile().then(props => props.date || defaultObj.date);
+}
+
+module.exports = { commit, date };

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "chai-as-promised": "^7.1.1",
     "mocha": "^3.4.2",
-    "sinon": "^1.17.7",
-    "sinon-chai": "^2.10.0",
-    "nock": "^9.0.0"
+    "nock": "^9.0.0",
+    "proxyquire": "^1.8.0",
+    "sinon": "^2.3.6",
+    "sinon-chai": "^2.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "author": "HMCTS Reform",
   "license": "MIT",
   "dependencies": {
+    "fs-extra": "^3.0.1",
+    "js-yaml": "^3.8.4",
     "superagent": "^3.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/nodejs-healthcheck",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Healthcheck endpoint for Reform nodejs applications",
   "main": "index.js",
   "scripts": {

--- a/test/chai-sinon.js
+++ b/test/chai-sinon.js
@@ -1,9 +1,11 @@
 const chai = require('chai');
+const chaiAsPromised = require("chai-as-promised");
 const expect = chai.expect;
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 chai.should();
 chai.use(sinonChai);
+chai.use(chaiAsPromised);
 
 module.exports = {
     expect,

--- a/test/unit/routesTest.js
+++ b/test/unit/routesTest.js
@@ -5,6 +5,7 @@ const {expect, sinon} = require('../chai-sinon'),
       routes = require('../../healthcheck/routes'),
       checks = require('../../healthcheck/checks'),
       outputs = require('../../healthcheck/outputs'),
+      versionFile = require('../../healthcheck/versionFile'),
       nock = require('nock');
 
 
@@ -16,6 +17,8 @@ describe('Routes', () => {
   ];
 
   beforeEach(() => {
+    sinon.stub(versionFile, 'commit');
+    versionFile.commit.resolves('abc1234');
     envKeys.forEach(key => {
       originalEnv[key] = process.env[key];
       process.env[key] = "test " + key;
@@ -23,6 +26,7 @@ describe('Routes', () => {
   });
 
   afterEach(() => {
+    versionFile.commit.restore();
     envKeys.forEach(key => {
       if (typeof originalEnv[key] === "undefined") {
         delete process.env[key];
@@ -36,25 +40,25 @@ describe('Routes', () => {
   describe('getBuildInfo', () => {
 
     it('should add build info from environment', () => {
-      expect(routes.getBuildInfo()).to.eql({
+      return expect(routes.getBuildInfo()).to.eventually.eql({
         environment: "test PACKAGES_ENVIRONMENT",
         project: "test PACKAGES_PROJECT",
         name: "test PACKAGES_NAME",
         version: "test PACKAGES_VERSION",
+        commit: 'abc1234'
       });
     });
 
     it('should include extra build info', () => {
-      expect(routes.getBuildInfo({"foo": "bar"}).extra).to.eql({
-        "foo": "bar"
-      });
+      const extra = routes.getBuildInfo({ foo: "bar" }).then(_ => _.extra);
+      return expect(extra).to.eventually.eql({ foo: "bar" });
     });
 
   });
 
   describe('configure', () => {
     let makeCheck = isOk => checks.RawCheck.create(() => isOk ? outputs.up() : outputs.down());
-    let makeReqRes = (done, expectedStatus, expectedJson) => {
+    let makeReqRes = (expectedStatus, expectedJson) => {
       let req = sinon.spy(),
           res = {};
       res.status = status => {
@@ -63,20 +67,19 @@ describe('Routes', () => {
       };
       res.json = json => {
         expect(json).to.eql(expectedJson);
-        done();
         return res;
       };
       return [req, res];
     };
 
-    it('should return 200 OK if all checks pass', (done) => {
+    it('should return 200 OK if all checks pass', () => {
       let route = routes.configure({
         checks: {
           check1: makeCheck(true),
           check2: makeCheck(true),
         }
       });
-      let [req, res] = makeReqRes(done, 200, {
+      let [req, res] = makeReqRes(200, {
         status: outputs.UP,
         check1: {status: "UP"},
         check2: {status: "UP"},
@@ -85,20 +88,21 @@ describe('Routes', () => {
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
           version: "test PACKAGES_VERSION",
+          commit: 'abc1234'
         }
       });
 
-      route(req, res);
+      return route(req, res);
     });
 
-    it('should return 500 DOWN if any checks fail', (done) => {
+    it('should return 500 DOWN if any checks fail', () => {
       let route = routes.configure({
         checks: {
           check1: makeCheck(false),
           check2: makeCheck(true),
         }
       });
-      let [req, res] = makeReqRes(done, 500, {
+      let [req, res] = makeReqRes(500, {
         status: "DOWN",
         check1: {status: "DOWN"},
         check2: {status: "UP"},
@@ -107,14 +111,15 @@ describe('Routes', () => {
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
           version: "test PACKAGES_VERSION",
+          commit: 'abc1234'
         }
       });
 
-      route(req, res);
+      return route(req, res);
 
     });
 
-    it('should return the extra build info', (done) => {
+    it('should return the extra build info', () => {
       let route = routes.configure({
         checks: {
           check1: makeCheck(true)
@@ -123,7 +128,7 @@ describe('Routes', () => {
           foo: "bar"
         }
       });
-      let [req, res] = makeReqRes(done, 200, {
+      let [req, res] = makeReqRes(200, {
         status: "UP",
         check1: {status: "UP"},
         buildInfo: {
@@ -131,13 +136,14 @@ describe('Routes', () => {
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
           version: "test PACKAGES_VERSION",
+          commit: 'abc1234',
           extra: {
             foo: "bar"
           }
         }
       });
 
-      route(req, res);
+      return route(req, res);
     });
 
   });

--- a/test/unit/routesTest.js
+++ b/test/unit/routesTest.js
@@ -18,7 +18,9 @@ describe('Routes', () => {
 
   beforeEach(() => {
     sinon.stub(versionFile, 'commit');
+    sinon.stub(versionFile, 'date');
     versionFile.commit.resolves('abc1234');
+    versionFile.date.resolves('Jan 1 1970');
     envKeys.forEach(key => {
       originalEnv[key] = process.env[key];
       process.env[key] = "test " + key;
@@ -27,6 +29,7 @@ describe('Routes', () => {
 
   afterEach(() => {
     versionFile.commit.restore();
+    versionFile.date.restore();
     envKeys.forEach(key => {
       if (typeof originalEnv[key] === "undefined") {
         delete process.env[key];
@@ -45,7 +48,8 @@ describe('Routes', () => {
         project: "test PACKAGES_PROJECT",
         name: "test PACKAGES_NAME",
         version: "test PACKAGES_VERSION",
-        commit: 'abc1234'
+        commit: 'abc1234',
+        date: 'Jan 1 1970'
       });
     });
 
@@ -88,7 +92,8 @@ describe('Routes', () => {
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
           version: "test PACKAGES_VERSION",
-          commit: 'abc1234'
+          commit: 'abc1234',
+          date: 'Jan 1 1970'
         }
       });
 
@@ -111,7 +116,8 @@ describe('Routes', () => {
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
           version: "test PACKAGES_VERSION",
-          commit: 'abc1234'
+          commit: 'abc1234',
+          date: 'Jan 1 1970'
         }
       });
 
@@ -137,6 +143,7 @@ describe('Routes', () => {
           name: "test PACKAGES_NAME",
           version: "test PACKAGES_VERSION",
           commit: 'abc1234',
+          date: 'Jan 1 1970',
           extra: {
             foo: "bar"
           }

--- a/test/unit/versionFile.js
+++ b/test/unit/versionFile.js
@@ -29,4 +29,19 @@ describe('versionFile', () => {
       return expect(versionFile.commit()).to.eventually.eql('unknown');
     });
   });
+
+  describe('date', () => {
+    it('should resolve the built date', () => {
+      fs.readFile.resolves('date: Jan 1 1970');
+      return expect(versionFile.date()).to.eventually.eql('Jan 1 1970');
+    });
+    it('should resolve "unkown" if no versionFile present', () => {
+      fs.readFile.rejects('no file found');
+      return expect(versionFile.date()).to.eventually.eql('unknown');
+    });
+    it('should resolve "unkown" if no commit present in version file', () => {
+      fs.readFile.resolves('foo: bar');
+      return expect(versionFile.date()).to.eventually.eql('unknown');
+    });
+  });
 });

--- a/test/unit/versionFile.js
+++ b/test/unit/versionFile.js
@@ -1,0 +1,32 @@
+'use strict'
+/* global describe, beforeEach, afterEach, it */
+
+const {expect, sinon} = require('../chai-sinon');
+const fs = require('fs-extra');
+const versionFile = require('../../healthcheck/versionFile');
+
+describe('versionFile', () => {
+
+  beforeEach(() => {
+    sinon.stub(fs, 'readFile');
+  });
+
+  afterEach(() => {
+    fs.readFile.restore();
+  });
+
+  describe('commit', () => {
+    it('should resolve the commit sha', () => {
+      fs.readFile.resolves('commit: abc1234');
+      return expect(versionFile.commit()).to.eventually.eql('abc1234');
+    });
+    it('should resolve "unkown" if no versionFile present', () => {
+      fs.readFile.rejects('no file found');
+      return expect(versionFile.commit()).to.eventually.eql('unknown');
+    });
+    it('should resolve "unkown" if no commit present in version file', () => {
+      fs.readFile.resolves('foo: bar');
+      return expect(versionFile.commit()).to.eventually.eql('unknown');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,20 +10,26 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
-balanced-match@^0.4.1:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 brace-expansion@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
-    balanced-match "^0.4.1"
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
+
+chai-as-promised@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  dependencies:
+    check-error "^1.0.2"
 
 "chai@>=1.9.2 <4.0.0", chai@^3.5.0:
   version "3.5.0"
@@ -32,6 +38,10 @@ browser-stdout@1.3.0:
     assertion-error "^1.0.1"
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 combined-stream@^1.0.5:
   version "1.0.5"
@@ -61,17 +71,11 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-debug@2.6.0:
+debug@2.6.0, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
-
-debug@^2.2.0:
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
 
 deep-eql@^0.1.3:
   version "0.1.3"
@@ -87,7 +91,7 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
 
-diff@3.2.0:
+diff@3.2.0, diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -99,19 +103,26 @@ extend@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+fill-keys@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fill-keys/-/fill-keys-1.0.2.tgz#9a8fa36f4e8ad634e3bf6b4f3c8882551452eb20"
+  dependencies:
+    is-object "~1.0.1"
+    merge-descriptors "~1.0.0"
+
 form-data@^2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.2.0.tgz#9a5e3b9295f980b2623cf64fa238b14cebca707b"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formatio@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.1.1.tgz#5ed3ccd636551097383465d996199100e86161e9"
+formatio@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
-    samsam "~1.1"
+    samsam "1.x"
 
 formidable@^1.1.1:
   version "1.1.1"
@@ -151,9 +162,17 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.1, inherits@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+inherits@2, inherits@~2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+is-object@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -218,9 +237,13 @@ lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lolex@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.3.2.tgz#7c3da62ffcb30f0f5a80a2566ca24e45d8a01f31"
+lolex@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+merge-descriptors@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
 methods@^1.1.1:
   version "1.1.2"
@@ -272,13 +295,17 @@ mocha@^3.4.2:
     mkdirp "0.5.1"
     supports-color "3.1.2"
 
+module-not-found-error@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/module-not-found-error/-/module-not-found-error-1.0.1.tgz#cf8b4ff4f29640674d6cdd02b0e3bc523c2bbdc0"
+
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ms@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+native-promise-only@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
 
 nock@^9.0.0:
   version "9.0.13"
@@ -303,6 +330,12 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -311,48 +344,64 @@ propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
 
+proxyquire@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/proxyquire/-/proxyquire-1.8.0.tgz#02d514a5bed986f04cbb2093af16741535f79edc"
+  dependencies:
+    fill-keys "^1.0.2"
+    module-not-found-error "^1.0.0"
+    resolve "~1.1.7"
+
 qs@^6.0.2, qs@^6.1.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
 
 readable-stream@^2.0.5:
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
     core-util-is "~1.0.0"
-    inherits "~2.0.1"
+    inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    safe-buffer "~5.0.1"
-    string_decoder "~1.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-safe-buffer@~5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+resolve@~1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-samsam@1.1.2, samsam@~1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+samsam@1.x, samsam@^1.1.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
 
 sinon-chai@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.10.0.tgz#6ab3008bb8cae9929e744d766574b4cf35f34b5b"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-2.11.0.tgz#93d90f989fff67ce45767077ffe575dde1faea6d"
 
-sinon@^1.17.7:
-  version "1.17.7"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-1.17.7.tgz#4542a4f49ba0c45c05eb2e9dd9d203e2b8efe0bf"
+sinon@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.6.tgz#95378e7e0f976a9712e9b4591ff5b39e73dc3dde"
   dependencies:
-    formatio "1.1.1"
-    lolex "1.3.2"
-    samsam "1.1.2"
-    util ">=0.10.3 <1"
+    diff "^3.1.0"
+    formatio "1.2.0"
+    lolex "^1.6.0"
+    native-promise-only "^0.8.1"
+    path-to-regexp "^1.7.0"
+    samsam "^1.1.3"
+    text-encoding "0.6.4"
+    type-detect "^4.0.0"
 
-string_decoder@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
   dependencies:
-    safe-buffer "~5.0.1"
+    safe-buffer "~5.1.0"
 
 superagent@^3.5.1:
   version "3.5.2"
@@ -375,6 +424,10 @@ supports-color@3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
+text-encoding@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
+
 type-detect@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-0.1.1.tgz#0ba5ec2a885640e470ea4e8505971900dac58822"
@@ -383,15 +436,13 @@ type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
 
+type-detect@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-"util@>=0.10.3 <1":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
-  dependencies:
-    inherits "2.0.1"
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+argparse@^1.0.7:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  dependencies:
+    sprintf-js "~1.0.2"
+
 assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
@@ -99,6 +105,10 @@ escape-string-regexp@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
 extend@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -128,6 +138,14 @@ formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
+fs-extra@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -142,6 +160,10 @@ glob@7.1.1:
     minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -178,6 +200,13 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+js-yaml@^3.8.4:
+  version "3.8.4"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
+
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -185,6 +214,12 @@ json-stringify-safe@^5.0.1:
 json3@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 lodash._baseassign@^3.0.0:
   version "3.2.0"
@@ -397,6 +432,10 @@ sinon@^2.3.6:
     text-encoding "0.6.4"
     type-detect "^4.0.0"
 
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
 string_decoder@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
@@ -439,6 +478,10 @@ type-detect@^1.0.0:
 type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
+
+universalify@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.0.tgz#9eb1c4651debcc670cc94f1a75762332bb967778"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This pull request aims to address the issue where old code gets packaged as a new version, bumping the RPM version correctly and so passing our smoketests.

It adds a new file `versionFile`, which encapsulates reading config from the yaml file that is added to the app root during packaging.

In order to add this to the buildInfo I've had to change how the `getBuildInfo` function works, making it return a promise that will eventually resolve to the buildInfo block. I've done this in a future proof way where if we want to move more things from env vars (which currently rely on Ansible to set them) to the version file packaged in the RPM it will be easy to do.