### PR TITLE
Pass req and res to the raw check

### DIFF
--- a/healthcheck/checks.js
+++ b/healthcheck/checks.js
@@ -42,9 +42,9 @@ class RawCheck {
     return new RawCheck(callback);
   }
 
-  call() {
+  call(req, res) {
     return new Promise((resolve) => {
-      resolve(this.callback());
+      resolve(this.callback(req, res));
     });
   }
 }
@@ -59,9 +59,9 @@ class CompositeCheck {
     return new CompositeCheck(checks);
   }
 
-  call() {
+  call(req, res) {
     let checks = Object.entries(this.checks),
-        promises = checks.map(check => check[1].call()),
+        promises = checks.map(check => check[1].call(req, res)),
         all = Promise.all(promises);
 
     return new Promise(resolve => {

--- a/healthcheck/routes.js
+++ b/healthcheck/routes.js
@@ -29,7 +29,7 @@ function configure(config) {
 
   return (req, res) => {
     return Promise
-      .all([check.call(), getBuildInfo(config.buildInfo)])
+      .all([check.call(req, res), getBuildInfo(config.buildInfo)])
       .then(([results, buildInfo]) => {
         const allOk = Object.values(results)
                             .every(result => result.status === outputs.UP);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/nodejs-healthcheck",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Healthcheck endpoint for Reform nodejs applications",
   "main": "index.js",
   "scripts": {

--- a/test/unit/checksTest.js
+++ b/test/unit/checksTest.js
@@ -91,6 +91,16 @@ describe('Checks', () => {
         });
       });
 
+      it('passes the express req and res to the callback', () => {
+        const expressRequest = sinon.spy();
+        const expressResponse = sinon.spy();
+        const check = new checks.RawCheck((req, res) => {
+          expect(req).to.eql(expressRequest);
+          expect(res).to.eql(expressResponse);
+        });
+        return check.call(expressRequest, expressResponse);
+      });
+
     });
 
   });
@@ -115,6 +125,23 @@ describe('Checks', () => {
           done();
         });
       });
+
+
+      it('passes the express req and res to the child checks', (done) => {
+        const expressRequest = sinon.spy();
+        const expressResponse = sinon.spy();
+        const childCheck = new checks.RawCheck((req, res) => {
+          expect(req).to.eql(expressRequest);
+          expect(res).to.eql(expressResponse);
+          done();
+        });
+        const check = new checks.CompositeCheck({
+          'child': childCheck
+        });
+
+        check.call(expressRequest, expressResponse);
+      });
+
     });
   });
 });


### PR DESCRIPTION
In Divorce we have feature toggles that adds to the express request which features are enabled and disabled.

This PR passes the express req and res objects, which are handling the healthcheck request itself, through to the raw check, so that it can pluck things from the req and render them in it's check.

