### PR TITLE
moved version to be a config value part of the version

### DIFF
--- a/healthcheck/routes.js
+++ b/healthcheck/routes.js
@@ -5,14 +5,15 @@ const checks = require('./checks'),
 
 function getBuildInfo(extra) {
   return Promise.all([
+    versionFile.version(),
     versionFile.commit(),
     versionFile.date()
-  ]).then(([commit, date]) => {
+  ]).then(([version, commit, date]) => {
     let buildInfo = {
       environment: process.env.PACKAGES_ENVIRONMENT || "unknown",
       project: process.env.PACKAGES_PROJECT || "unknown",
       name: process.env.PACKAGES_NAME || "unknown",
-      version: process.env.PACKAGES_VERSION || "unknown",
+      version,
       commit,
       date
     };

--- a/healthcheck/versionFile.js
+++ b/healthcheck/versionFile.js
@@ -16,7 +16,9 @@ const versionFile = () => {
 }
 
 const version = () => {
-  return versionFile().then(props => props.version + ((props.build) ? "-" + props.build : "") || defaultObj.version);
+  return versionFile().then(props => {
+    return (props.version) ? (props.build) ?  props.version + "-" + props.build : props.version : defaultObj.version
+  });
 };
 
 const commit = () => {

--- a/healthcheck/versionFile.js
+++ b/healthcheck/versionFile.js
@@ -1,14 +1,16 @@
 const fs = require('fs-extra');
 const yaml = require('js-yaml');
 
-const defaultObj = {
-  version: 'unknown',
-  commit: 'unknown',
-  date: 'unknown'
-};
+let defaultObj
 
 const versionFile = () => {
   const versionFilePath = `${process.env.NODE_PATH || '.'}/version`;
+
+   defaultObj = {
+    version: process.env.PACKAGES_VERSION || 'unknown',
+    commit: 'unknown',
+    date: 'unknown'
+  };
 
   return fs.readFile(versionFilePath)
     .then(yaml.safeLoad)

--- a/healthcheck/versionFile.js
+++ b/healthcheck/versionFile.js
@@ -2,6 +2,7 @@ const fs = require('fs-extra');
 const yaml = require('js-yaml');
 
 const defaultObj = {
+  version: 'unknown',
   commit: 'unknown',
   date: 'unknown'
 };
@@ -14,6 +15,10 @@ const versionFile = () => {
     .catch((err) => defaultObj);
 }
 
+const version = () => {
+  return versionFile().then(props => props.version + ((props.build) ? "-" + props.build : "") || defaultObj.version);
+};
+
 const commit = () => {
   return versionFile().then(props => props.commit || defaultObj.commit);
 };
@@ -22,4 +27,4 @@ const date = () => {
   return versionFile().then(props => props.date || defaultObj.date);
 }
 
-module.exports = { commit, date };
+module.exports = { version, commit, date };

--- a/test/unit/routesTest.js
+++ b/test/unit/routesTest.js
@@ -12,15 +12,16 @@ const {expect, sinon} = require('../chai-sinon'),
 describe('Routes', () => {
   let originalEnv = {};
   const envKeys = [
-    'PACKAGES_ENVIRONMENT', 'PACKAGES_PROJECT',
-    'PACKAGES_NAME', 'PACKAGES_VERSION'
+    'PACKAGES_ENVIRONMENT', 'PACKAGES_PROJECT', 'PACKAGES_NAME'
   ];
 
   beforeEach(() => {
     sinon.stub(versionFile, 'commit');
     sinon.stub(versionFile, 'date');
+    sinon.stub(versionFile, 'version');
     versionFile.commit.resolves('abc1234');
     versionFile.date.resolves('Jan 1 1970');
+    versionFile.version.resolves('1.4.3-42');
     envKeys.forEach(key => {
       originalEnv[key] = process.env[key];
       process.env[key] = "test " + key;
@@ -30,6 +31,7 @@ describe('Routes', () => {
   afterEach(() => {
     versionFile.commit.restore();
     versionFile.date.restore();
+    versionFile.version.restore();
     envKeys.forEach(key => {
       if (typeof originalEnv[key] === "undefined") {
         delete process.env[key];
@@ -47,7 +49,7 @@ describe('Routes', () => {
         environment: "test PACKAGES_ENVIRONMENT",
         project: "test PACKAGES_PROJECT",
         name: "test PACKAGES_NAME",
-        version: "test PACKAGES_VERSION",
+        version: "1.4.3-42",
         commit: 'abc1234',
         date: 'Jan 1 1970'
       });
@@ -91,7 +93,7 @@ describe('Routes', () => {
           environment: "test PACKAGES_ENVIRONMENT",
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
-          version: "test PACKAGES_VERSION",
+          version: "1.4.3-42",
           commit: 'abc1234',
           date: 'Jan 1 1970'
         }
@@ -115,7 +117,7 @@ describe('Routes', () => {
           environment: "test PACKAGES_ENVIRONMENT",
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
-          version: "test PACKAGES_VERSION",
+          version: "1.4.3-42",
           commit: 'abc1234',
           date: 'Jan 1 1970'
         }
@@ -141,7 +143,7 @@ describe('Routes', () => {
           environment: "test PACKAGES_ENVIRONMENT",
           project: "test PACKAGES_PROJECT",
           name: "test PACKAGES_NAME",
-          version: "test PACKAGES_VERSION",
+          version: "1.4.3-42",
           commit: 'abc1234',
           date: 'Jan 1 1970',
           extra: {

--- a/test/unit/versionFile.js
+++ b/test/unit/versionFile.js
@@ -15,16 +15,45 @@ describe('versionFile', () => {
     fs.readFile.restore();
   });
 
+  describe('version', () => {
+    it('should resolve the version', () => {
+      fs.readFile.resolves('version: 1.4.3\nbuild: 42');
+      return expect(versionFile.version()).to.eventually.eql('1.4.3-42');
+    });
+
+    it('should resolve the version even if build is missing', () => {
+      fs.readFile.resolves('version: 1.4.3');
+      return expect(versionFile.version()).to.eventually.eql('1.4.3');
+    });
+
+    it('should resolve "unknown" if no version present in version file but build is there', () => {
+      fs.readFile.resolves('build: 42');
+      return expect(versionFile.version()).to.eventually.eql('unknown');
+    });
+
+
+    it('should resolve "unknown" if no versionFile present', () => {
+      fs.readFile.rejects('no file found');
+      return expect(versionFile.version()).to.eventually.eql('unknown');
+    });
+
+    it('should resolve "unknown" if no version present in version file', () => {
+      fs.readFile.resolves('foo: bar');
+      return expect(versionFile.version()).to.eventually.eql('unknown');
+    });
+  });
+
+
   describe('commit', () => {
     it('should resolve the commit sha', () => {
       fs.readFile.resolves('commit: abc1234');
       return expect(versionFile.commit()).to.eventually.eql('abc1234');
     });
-    it('should resolve "unkown" if no versionFile present', () => {
+    it('should resolve "unknown" if no versionFile present', () => {
       fs.readFile.rejects('no file found');
       return expect(versionFile.commit()).to.eventually.eql('unknown');
     });
-    it('should resolve "unkown" if no commit present in version file', () => {
+    it('should resolve "unknown" if no commit present in version file', () => {
       fs.readFile.resolves('foo: bar');
       return expect(versionFile.commit()).to.eventually.eql('unknown');
     });
@@ -35,11 +64,11 @@ describe('versionFile', () => {
       fs.readFile.resolves('date: Jan 1 1970');
       return expect(versionFile.date()).to.eventually.eql('Jan 1 1970');
     });
-    it('should resolve "unkown" if no versionFile present', () => {
+    it('should resolve "unknown" if no versionFile present', () => {
       fs.readFile.rejects('no file found');
       return expect(versionFile.date()).to.eventually.eql('unknown');
     });
-    it('should resolve "unkown" if no commit present in version file', () => {
+    it('should resolve "unknown" if no commit present in version file', () => {
       fs.readFile.resolves('foo: bar');
       return expect(versionFile.date()).to.eventually.eql('unknown');
     });

--- a/test/unit/versionFile.js
+++ b/test/unit/versionFile.js
@@ -31,7 +31,6 @@ describe('versionFile', () => {
       return expect(versionFile.version()).to.eventually.eql('unknown');
     });
 
-
     it('should resolve "unknown" if no versionFile present', () => {
       fs.readFile.rejects('no file found');
       return expect(versionFile.version()).to.eventually.eql('unknown');
@@ -41,6 +40,50 @@ describe('versionFile', () => {
       fs.readFile.resolves('foo: bar');
       return expect(versionFile.version()).to.eventually.eql('unknown');
     });
+
+
+
+    describe('version with Environment Variables', () => {
+    let versionFileWithEnv
+
+      beforeEach(() => {
+          process.env["PACKAGES_VERSION"] = 'v1.42'
+          process.env.PACKAGES_VERSION = 'v1.42'
+          versionFileWithEnv = require('../../healthcheck/versionFile')
+      });
+
+      afterEach(() => {
+        delete process.env.PACKAGES_VERSION
+        delete process.env["PACKAGES_VERSION"]
+      });
+
+        it('should resolve the version to Version even with Environment Variables', () => {
+          fs.readFile.resolves('version: 1.4.3\nbuild: 42');
+          return expect(versionFileWithEnv.version()).to.eventually.eql('1.4.3-42');
+        });
+
+        it('should resolve the version even if build is missing even with Environment Variables', () => {
+          fs.readFile.resolves('version: 1.4.3');
+          return expect(versionFile.version()).to.eventually.eql('1.4.3');
+        });
+
+        it('should resolve the version to Environment Variables if no version present in version file but build is there', () => {
+          fs.readFile.resolves('build: 42');
+          return expect(versionFile.version()).to.eventually.eql('v1.42');
+        });
+
+        it('should resolve the version to Environment Variables "v1.42" when versionFile has no version', () => {
+          fs.readFile.resolves('foo: bar');
+          return expect(versionFileWithEnv.version()).to.eventually.eql('v1.42');
+        });
+
+        it('should resolve the version to Environment Variables "v1.42" when no versionFile exists', () => {
+          fs.readFile.rejects('no file found');
+          return expect(versionFileWithEnv.version()).to.eventually.eql('v1.42');
+        });
+
+     });
+
   });
 
 


### PR DESCRIPTION
Notes:
* Made it so the version number is take from a "version" file not environmental variables.
* This could potenial be refined by actually take the main project package.json as a requirement similar to doing  
```bash
node -pe "require('./package.json').version"
```
* However this should be fit for purpose until then.
