### PR TITLE
Add detailed information on web checks

### DIFF
--- a/healthcheck/checks.js
+++ b/healthcheck/checks.js
@@ -17,7 +17,7 @@ class WebCheck {
   }
 
   defaultCallback (err, res) {
-    return !err && res.status === 200 ? outputs.up({details:{url:this.url}}) : outputs.down(err)
+    return !err && res.status === 200 ? outputs.up({ details: { url: this.url } }) : outputs.down(err)
   }
 
   call () {

--- a/healthcheck/checks.js
+++ b/healthcheck/checks.js
@@ -17,7 +17,7 @@ class WebCheck {
   }
 
   defaultCallback (err, res) {
-    return !err && res.status === 200 ? outputs.up() : outputs.down(err)
+    return !err && res.status === 200 ? outputs.up({details:{url:this.url}}) : outputs.down(err)
   }
 
   call () {

--- a/test/unit/checksTest.js
+++ b/test/unit/checksTest.js
@@ -20,7 +20,7 @@ describe('Checks', () => {
         request.reply(200, 'OK')
 
         check.call().then((result) => {
-          expect(result).to.eql({ status: 'UP', details : { url: 'https://example.com/status' } })
+          expect(result).to.eql({ status: 'UP', details: { url: 'https://example.com/status' } })
           done()
         })
       });

--- a/test/unit/checksTest.js
+++ b/test/unit/checksTest.js
@@ -20,7 +20,7 @@ describe('Checks', () => {
         request.reply(200, 'OK')
 
         check.call().then((result) => {
-          expect(result).to.eql({ status: 'UP' })
+          expect(result).to.eql({ status: 'UP', { details : { url: 'https://example.com/status' } } })
           done()
         })
       });

--- a/test/unit/checksTest.js
+++ b/test/unit/checksTest.js
@@ -20,7 +20,7 @@ describe('Checks', () => {
         request.reply(200, 'OK')
 
         check.call().then((result) => {
-          expect(result).to.eql({ status: 'UP', { details : { url: 'https://example.com/status' } } })
+          expect(result).to.eql({ status: 'UP', details : { url: 'https://example.com/status' } })
           done()
         })
       });


### PR DESCRIPTION
This pull request add url as output of default like:

```json
{
  "status": "UP",
  "sample": {
    "details": {
      "url": "http://sample.com"
    },
    "status": "UP"
  }
}
```

